### PR TITLE
fix: exclude nested Release PRs from changelog

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -134,8 +134,10 @@ jobs:
                               if [ -n "$INNER_PR_INFO" ]; then
                                 INNER_PR_TITLE=$(echo "$INNER_PR_INFO" | jq -r '.title')
                                 INNER_PR_AUTHOR=$(echo "$INNER_PR_INFO" | jq -r '.author.login')
-                                # Don't skip any PRs from within Release PRs
-                                add_pr_to_list "$INNER_PR_NUM" "#$INNER_PR_NUM $INNER_PR_TITLE" "$INNER_PR_AUTHOR"
+                                # Skip Release PRs even when found inside other Release PRs
+                                if [[ ! "$INNER_PR_TITLE" =~ ^Release\ to ]]; then
+                                  add_pr_to_list "$INNER_PR_NUM" "#$INNER_PR_NUM $INNER_PR_TITLE" "$INNER_PR_AUTHOR"
+                                fi
                               fi
                             fi
                           done


### PR DESCRIPTION
## Summary
- Skip Release PRs even when found inside other Release PRs
- Ensures cleaner changelog without duplicate Release entries

## Test plan
- [x] Modified workflow to check Release PR titles in nested PRs
- [ ] Create PR and merge to develop
- [ ] Verify staging PR is created
- [ ] Merge to staging and verify production PR
- [ ] Merge to production and check release notes don't contain "Release to" entries

🤖 Generated with [Claude Code](https://claude.ai/code)